### PR TITLE
Add a umask wrapper to the creation of sockets

### DIFF
--- a/ioflo/base/aiding.py
+++ b/ioflo/base/aiding.py
@@ -601,7 +601,7 @@ class SocketUxdNb(object):
        Needs socket module
     """
 
-    def __init__(self, ha=None, bufsize = 1024, path = '', log = False):
+    def __init__(self, ha=None, bufsize = 1024, path = '', log = False, umask=None):
         """Initialization method for instance.
 
            ha = host address duple (host, port)
@@ -617,6 +617,7 @@ class SocketUxdNb(object):
         self.txLog = None #transmit log
         self.rxLog = None #receive log
         self.log = log
+        self.umask = umask
 
     def openLogs(self, path = ''):
         """Open log files
@@ -666,11 +667,16 @@ class SocketUxdNb(object):
         self.ss.setblocking(0) #non blocking socket
 
         #bind to Host Address Port
+        if self.umask:
+            cumask = os.umask(self.umask)
+        else:
+            cumask = os.umask()
         try:
             self.ss.bind(self.ha)
         except socket.error, e:
             console.terse("socket.error = {0}\n".format(e))
             return False
+        os.umask(cumask)
 
         self.ha = self.ss.getsockname() #get resolved ha after bind
 


### PR DESCRIPTION
This makes is easy to set the creation umask for the socket file to
ensure that the correct filesystem permissions are set per the given
application
