### PR TITLE
Fixes for invalid http requests

### DIFF
--- a/ioflo/aio/http/httping.py
+++ b/ioflo/aio/http/httping.py
@@ -565,7 +565,7 @@ def parseRequestLine(line):
     method, path, version, extra = aiding.repack(4, line.split(), default = u'')
 
     if not version.startswith("HTTP/"):
-        raise UnkownProtocol(version)
+        raise UnknownProtocol(version)
 
     if method not in METHODS:
         raise BadMethod(method)

--- a/ioflo/aio/http/serving.py
+++ b/ioflo/aio/http/serving.py
@@ -711,6 +711,10 @@ class Valet(object):
                     continue
 
                 if requestant.ended:
+                    if requestant.errored:
+                        self.closeConnection(ca)
+                        continue
+
                     console.concise("Parsed Request:\n{0} {1} {2}\n"
                                     "{3}\n{4}\n".format(requestant.method,
                                                         requestant.path,


### PR DESCRIPTION
We have spotted a couple of issues with the server when trying to parse an invalid http request, ie sending an empty header or sending an incorrect header.

Keep up de the good work!
