### PR TITLE
Removed call to serial nonblocking for systems without it defined

### DIFF
--- a/ioflo/aio/serial/serialing.py
+++ b/ioflo/aio/serial/serialing.py
@@ -314,7 +314,8 @@ class SerialNb(object):
                                     baudrate=self.speed,
                                     timeout=0,
                                     writeTimeout=0)
-        self.serial.nonblocking()
+        if getattr(self.serial, "nonblocking", False):
+            self.serial.nonblocking()
         self.serial.reset_input_buffer()
         self.opened = True
 


### PR DESCRIPTION
Windows systems encounter an error here since nonblocking is not defined on that system. According to the pyserial [docs](http://pyserial.readthedocs.io/en/latest/pyserial_api.html#serial.Serial.nonblocking), the method is deprecated anyway. For compatibility with older pyserial versions, we still use it where available.